### PR TITLE
Feat/teleport support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "kr"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@ A fast, lightweight Kubernetes TUI built in Rust.
 - **Wide view** — toggle extended columns (IP, Node, Image, etc.) with `w`
 - **Fuzzy filter** — type `/` to filter resources by name
 - **Context & namespace switching** — switch clusters and namespaces without leaving the TUI
+- **Teleport support** — log into `tsh` clusters straight from the context picker, no `tsh kube login` beforehand
+- **Namespace discovery** — finds your namespaces even without cluster-wide `list namespaces` permission
 - **Describe & edit** — `kubectl describe` and `kubectl edit` in embedded views
 - **RBAC-aware** — graceful handling of 403 Forbidden errors
 - **Loading feedback** — animated spinner with elapsed time
-- **Persistent state** — remembers namespaces per context across sessions
+- **Persistent state** — remembers namespaces and your last namespace per context across sessions
 
 ## Installation
 
@@ -72,6 +74,9 @@ kr -c "get pods -n kube-system"
 |-----|--------|
 | `c` | Switch context (cluster) |
 | `n` | Switch namespace |
+
+In the context picker, entries marked `⚡` are Teleport clusters you have access to but are not
+logged into yet — see [Teleport](#teleport).
 
 ### Pods
 
@@ -145,25 +150,61 @@ Press `V` in the log view to select one or more lines to copy.
 | `d` / `Delete` | Stop selected forward |
 | `Esc` | Close |
 
+## Teleport
+
+Entirely optional. Without `tsh` installed, kr behaves exactly as a plain kubeconfig client and
+none of this applies.
+
+When `tsh` is present and you have an active Teleport session, the context picker (`c`) also lists
+clusters you have access to but have **not** run `tsh kube login` for. They appear as
+`⚡ cluster-name (teleport)`. Selecting one runs the login for you — kr drops out of the TUI so MFA
+prompts and browser redirects work normally — then switches to the new context. If your Teleport
+session has expired, the picker offers `⚡ Log in to Teleport` instead.
+
+kr never files access requests on your behalf: `tsh kube login` is always invoked with
+`--disable-access-request`, since selecting a row in a list should not create a server-side
+approval request.
+
+## Namespaces
+
+Some clusters grant access to individual namespaces without allowing `list namespaces` at the
+cluster scope, which normally leaves the namespace picker empty. kr tries three sources in order:
+
+1. the Kubernetes API
+2. `kubectl get namespaces`
+3. your Teleport role grants, read locally from `tsh status`
+
+Source 3 is a union across all your Teleport roles, so kr narrows it to the namespaces that
+actually work in the current cluster by asking the cluster what you are allowed to do in each one
+(`SelfSubjectRulesReview`, which needs no special permission).
+
+kr does not invent a namespace. If nothing is known yet, none is selected and no requests are made
+— so you get an empty view instead of a confusing permission error. Once the list is known:
+
+- exactly one namespace, or a confirmed `default` → selected automatically
+- otherwise → the namespace picker opens
+
+Your choice is remembered per context, so later switches land where you left off.
+
 ## Requirements
 
 - Rust 1.75+ (to build from source)
 - `kubectl` configured with a valid kubeconfig
 - `kubectl` binary in PATH (for describe, edit, CLI mode)
+- `tsh` in PATH — optional, only for [Teleport](#teleport) clusters
 
 ## Configuration
 
-kr stores persistent state (namespace history per context) in:
+kr stores persistent state (namespace history and last namespace per context) in `kr/state.json`,
+and TUI logs in `kr/kr.log`, under your platform's config directory:
 
-```
-~/.config/kr/state.json
-```
+| Platform | Directory |
+|----------|-----------|
+| Linux | `$XDG_CONFIG_HOME/kr` or `~/.config/kr` |
+| macOS | `~/Library/Application Support/kr` |
+| Windows | `%APPDATA%\kr` |
 
-Logs (TUI mode) are written to:
-
-```
-~/.config/kr/kr.log
-```
+The log is rotated to `kr.log.1` at startup once it exceeds 16 MB.
 
 ## License
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 use crate::models::{
-    AppMode, KubeResource, KubeResourceEvent, PendingAction, ResourceType, SortDirection,
+    AppMode, ContextEntry, KubeResource, KubeResourceEvent, NamespaceOrigin, PendingAction,
+    ResourceType, SortDirection,
 };
 use crate::state::AppState;
 use k8s_openapi::api::{
@@ -34,6 +35,7 @@ pub struct ActivePortForward {
 
 pub(crate) const MAX_LOG_LINES: usize = 10_000;
 pub(crate) const LOG_CHROME_LINES: usize = 6;
+pub(crate) const DEFAULT_NAMESPACE: &str = "default";
 
 pub(crate) fn contains_ascii_ci(haystack: &str, needle_lower: &str) -> bool {
     if needle_lower.is_empty() {
@@ -58,6 +60,9 @@ pub struct App {
     pub secret_store: Option<Store<Secret>>,
     pub current_context: String,
     pub pending_context: Option<String>,
+    pub pending_teleport_login: Option<crate::k8s::teleport::Login>,
+    pub teleport: crate::k8s::teleport::State,
+    pub namespace_prompt_pending: bool,
 
     pub event_tx: UnboundedSender<KubeResourceEvent>,
 
@@ -151,8 +156,13 @@ impl App {
         Self,
         tokio::sync::mpsc::UnboundedReceiver<KubeResourceEvent>,
     )> {
-        let namespace =
-            crate::k8s::config::get_context_namespace().unwrap_or_else(|_| "default".to_string());
+        let app_state = AppState::load();
+        let context = crate::k8s::config::get_current_context().unwrap_or_default();
+        let namespace = app_state
+            .last_namespace(&context)
+            .map(str::to_string)
+            .or_else(|| crate::k8s::config::get_context_namespace().ok().flatten())
+            .unwrap_or_default();
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
         Ok((
@@ -177,6 +187,9 @@ impl App {
                 log_scroll_offset: None,
                 current_context: "default".into(),
                 pending_context: None,
+                pending_teleport_login: None,
+                teleport: Default::default(),
+                namespace_prompt_pending: false,
                 available_contexts: Vec::new(),
                 available_namespaces: Vec::new(),
                 filtered_namespaces: Vec::new(),
@@ -230,7 +243,7 @@ impl App {
                 port_forward_list_state: ListState::default(),
                 port_forward_next_id: 0,
                 port_forward_stopped_ids: HashSet::new(),
-                app_state: AppState::load(),
+                app_state,
             },
             rx,
         ))
@@ -646,6 +659,96 @@ impl App {
         self.log_search_pending = false;
     }
 
+    pub fn context_entry_count(&self) -> usize {
+        self.available_contexts.len()
+            + self.teleport.clusters().len()
+            + usize::from(self.teleport.needs_login())
+    }
+
+    pub fn context_entry(&self, index: usize) -> Option<ContextEntry<'_>> {
+        if let Some(ctx) = self.available_contexts.get(index) {
+            return Some(ContextEntry::Kubeconfig(ctx));
+        }
+        let clusters = self.teleport.clusters();
+        let index = index.saturating_sub(self.available_contexts.len());
+        if let Some(cluster) = clusters.get(index) {
+            return Some(ContextEntry::Teleport(cluster));
+        }
+        if self.teleport.needs_login() && index == clusters.len() {
+            return Some(ContextEntry::TeleportLogin);
+        }
+        None
+    }
+
+    pub fn load_teleport_clusters(&self) {
+        let tx = self.event_tx.clone();
+        tokio::spawn(async move {
+            let _ = tx.send(KubeResourceEvent::TeleportState(
+                crate::k8s::teleport::probe().await,
+            ));
+        });
+    }
+
+    pub fn apply_namespaces(
+        &mut self,
+        context: &str,
+        namespaces: &[String],
+        origin: &NamespaceOrigin,
+    ) -> bool {
+        if context != self.current_context {
+            tracing::debug!("dropping stale namespace list for '{context}'");
+            return false;
+        }
+        self.available_namespaces = match origin.supersedes() {
+            Some(probed) => self.app_state.replace_namespaces(
+                context,
+                namespaces,
+                probed,
+                &self.current_namespace,
+            ),
+            None => self.app_state.merge_namespaces(context, namespaces),
+        };
+
+        if !self.has_namespace() {
+            self.resolve_namespace(origin.is_verified());
+        }
+        true
+    }
+
+    pub fn has_namespace(&self) -> bool {
+        !self.current_namespace.is_empty()
+    }
+
+    fn resolve_namespace(&mut self, verified: bool) {
+        let choice = match self.available_namespaces.as_slice() {
+            _ if !verified => None,
+            [] => None,
+            [only] => Some(only.clone()),
+            many => many.iter().find(|ns| *ns == DEFAULT_NAMESPACE).cloned(),
+        };
+        match choice {
+            Some(ns) => self.current_namespace = ns,
+            None => self.prompt_for_namespace(),
+        }
+    }
+
+    pub fn prompt_for_namespace(&mut self) {
+        if self.available_namespaces.is_empty() {
+            return;
+        }
+        if self.mode != AppMode::List {
+            self.namespace_prompt_pending = true;
+            return;
+        }
+        self.namespace_prompt_pending = false;
+        self.namespace_input.clear();
+        self.namespace_typing = false;
+        self.filtered_namespaces
+            .clone_from(&self.available_namespaces);
+        self.popup_state.select(Some(0));
+        self.mode = AppMode::NamespaceSelect;
+    }
+
     pub fn load_namespaces(&self) {
         let client = self.client.clone();
         let current_ns = self.current_namespace.clone();
@@ -655,27 +758,38 @@ impl App {
             use k8s_openapi::api::core::v1::Namespace;
             use kube::Api;
             use kube::api::ListParams;
+            let probe_client = client.clone();
             let ns_api: Api<Namespace> = Api::all(client);
-            if let Ok(ns_list) = ns_api.list(&ListParams::default()).await {
-                let namespaces: Vec<String> = ns_list
-                    .iter()
-                    .map(|n| n.metadata.name.clone().unwrap_or_default())
-                    .collect();
-                let _ = tx.send(KubeResourceEvent::NamespacesLoaded(namespaces));
-                return;
-            }
+            let list_denied = match ns_api.list(&ListParams::default()).await {
+                Ok(ns_list) => {
+                    let namespaces: Vec<String> = ns_list
+                        .iter()
+                        .map(|n| n.metadata.name.clone().unwrap_or_default())
+                        .collect();
+                    let _ = tx.send(KubeResourceEvent::NamespacesLoaded {
+                        context: ctx,
+                        namespaces,
+                        origin: NamespaceOrigin::Listed,
+                    });
+                    return;
+                }
+                Err(e) => {
+                    matches!(&e, kube::Error::Api(resp) if crate::k8s::access::is_access_denied(resp))
+                }
+            };
 
-            if let Ok(output) = tokio::process::Command::new("kubectl")
-                .args([
-                    "get",
-                    "namespaces",
-                    "--context",
-                    &ctx,
-                    "-o",
-                    "jsonpath={.items[*].metadata.name}",
-                ])
-                .output()
-                .await
+            if !list_denied
+                && let Ok(output) = tokio::process::Command::new("kubectl")
+                    .args([
+                        "get",
+                        "namespaces",
+                        "--context",
+                        &ctx,
+                        "-o",
+                        "jsonpath={.items[*].metadata.name}",
+                    ])
+                    .output()
+                    .await
                 && output.status.success()
             {
                 let text = String::from_utf8_lossy(&output.stdout);
@@ -685,12 +799,34 @@ impl App {
                     .filter(|s| !s.is_empty())
                     .collect();
                 if !namespaces.is_empty() {
-                    let _ = tx.send(KubeResourceEvent::NamespacesLoaded(namespaces));
+                    let _ = tx.send(KubeResourceEvent::NamespacesLoaded {
+                        context: ctx,
+                        namespaces,
+                        origin: NamespaceOrigin::Listed,
+                    });
                     return;
                 }
             }
 
-            let _ = tx.send(KubeResourceEvent::NamespacesLoaded(vec![current_ns]));
+            let granted = crate::k8s::teleport::grantable_namespaces(&ctx).await;
+            if !granted.is_empty() {
+                let (namespaces, origin) =
+                    crate::k8s::access::filter_relevant(&probe_client, granted)
+                        .await
+                        .into_parts();
+                let _ = tx.send(KubeResourceEvent::NamespacesLoaded {
+                    context: ctx,
+                    namespaces,
+                    origin,
+                });
+                return;
+            }
+
+            let _ = tx.send(KubeResourceEvent::NamespacesLoaded {
+                context: ctx,
+                namespaces: Vec::from_iter(Some(current_ns).filter(|ns| !ns.is_empty())),
+                origin: NamespaceOrigin::Unverified,
+            });
         });
     }
 
@@ -1185,6 +1321,9 @@ impl App {
             log_scroll_offset: None,
             current_context: "test-context".into(),
             pending_context: None,
+            pending_teleport_login: None,
+            teleport: Default::default(),
+            namespace_prompt_pending: false,
             available_contexts: vec!["ctx1".into(), "ctx2".into()],
             available_namespaces: vec!["default".into(), "kube-system".into()],
             filtered_namespaces: vec!["default".into(), "kube-system".into()],
@@ -1238,7 +1377,10 @@ impl App {
             port_forward_list_state: ListState::default(),
             port_forward_next_id: 0,
             port_forward_stopped_ids: HashSet::new(),
-            app_state: AppState::default(),
+            app_state: AppState {
+                no_persist: true,
+                ..Default::default()
+            },
         }
     }
 
@@ -1300,6 +1442,7 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::k8s::teleport::State as TeleportState;
     use crate::models::KubeResource;
     use k8s_openapi::ByteString;
     use k8s_openapi::api::core::v1::{Pod, Secret};
@@ -1593,7 +1736,6 @@ mod tests {
         app.log_buffer.push_back("line1".into());
         app.log_loading_history = true;
 
-        // Response has fewer lines than requested = pod has no more history
         app.merge_log_history(1, vec!["line1".into()]);
 
         assert!(app.log_history_exhausted);
@@ -1604,13 +1746,11 @@ mod tests {
         let mut app = App::new_test();
         app.log_generation = 1;
         app.log_tail_lines = 200;
-        // Fill buffer near capacity
         for i in 0..MAX_LOG_LINES - 2 {
             app.log_buffer.push_back(format!("existing{i}"));
         }
         app.log_loading_history = true;
 
-        // History offers 10 new lines, but only 2 can fit
         let mut history: Vec<String> = (0..10).map(|i| format!("new{i}")).collect();
         history.push("existing0".into());
         app.merge_log_history(1, history);
@@ -2444,5 +2584,279 @@ mod tests {
     async fn build_log_selection_text_none_without_anchor() {
         let app = App::new_test();
         assert!(app.build_log_selection_text().is_none());
+    }
+
+    #[tokio::test]
+    async fn context_entries_without_teleport() {
+        let app = App::new_test();
+        assert_eq!(app.context_entry_count(), 2);
+        assert_eq!(app.context_entry(0), Some(ContextEntry::Kubeconfig("ctx1")));
+        assert_eq!(app.context_entry(1), Some(ContextEntry::Kubeconfig("ctx2")));
+        assert_eq!(app.context_entry(2), None);
+    }
+
+    #[tokio::test]
+    async fn context_entries_append_teleport_clusters() {
+        let mut app = App::new_test();
+        app.teleport = TeleportState::Available(vec!["k8s.a".into(), "k8s.b".into()]);
+        assert_eq!(app.context_entry_count(), 4);
+        assert_eq!(app.context_entry(1), Some(ContextEntry::Kubeconfig("ctx2")));
+        assert_eq!(app.context_entry(2), Some(ContextEntry::Teleport("k8s.a")));
+        assert_eq!(app.context_entry(3), Some(ContextEntry::Teleport("k8s.b")));
+        assert_eq!(app.context_entry(4), None);
+    }
+
+    #[tokio::test]
+    async fn context_entries_include_login_prompt_when_required() {
+        let mut app = App::new_test();
+        app.teleport = TeleportState::NeedsLogin;
+        assert_eq!(app.context_entry_count(), 3);
+        assert_eq!(app.context_entry(2), Some(ContextEntry::TeleportLogin));
+        assert_eq!(app.context_entry(3), None);
+    }
+
+    #[tokio::test]
+    async fn test_app_never_persists_state() {
+        let app = App::new_test();
+        assert!(
+            app.app_state.no_persist,
+            "App::new_test() must not write to the real ~/.config/kr/state.json"
+        );
+    }
+
+    #[tokio::test]
+    async fn namespaces_for_current_context_are_merged() {
+        let mut app = App::new_test();
+        app.current_context = "ctx-a".into();
+        assert!(app.apply_namespaces("ctx-a", &["ns-1".to_string()], &NamespaceOrigin::Listed));
+        assert!(app.available_namespaces.contains(&"ns-1".to_string()));
+    }
+
+    #[tokio::test]
+    async fn stale_namespaces_from_other_context_are_dropped() {
+        let mut app = App::new_test();
+        app.current_context = "ctx-b".into();
+        app.available_namespaces = vec!["kept".into()];
+        assert!(!app.apply_namespaces("ctx-a", &["leaked".to_string()], &NamespaceOrigin::Listed));
+        assert_eq!(app.available_namespaces, vec!["kept".to_string()]);
+        assert!(app.app_state.get_namespaces("ctx-a").is_empty());
+        assert!(app.app_state.get_namespaces("ctx-b").is_empty());
+    }
+
+    #[tokio::test]
+    async fn authoritative_namespaces_replace_stale_entries() {
+        let mut app = App::new_test();
+        app.current_context = "ctx-a".into();
+        app.current_namespace = "default".into();
+        app.app_state.add_namespace("ctx-a", "revoked-ns");
+        let probed = ["live-ns".to_string(), "revoked-ns".to_string()];
+        assert!(app.apply_namespaces(
+            "ctx-a",
+            &["live-ns".to_string()],
+            &NamespaceOrigin::Probed(probed.to_vec())
+        ));
+        assert_eq!(app.available_namespaces, vec!["default", "live-ns"]);
+    }
+
+    #[tokio::test]
+    async fn authoritative_replace_keeps_never_probed_namespaces() {
+        let mut app = App::new_test();
+        app.current_context = "ctx-a".into();
+        app.current_namespace = "default".into();
+        app.app_state.add_namespace("ctx-a", "manual-ns");
+        app.app_state.add_namespace("ctx-a", "revoked-ns");
+        let probed = ["live-ns".to_string(), "revoked-ns".to_string()];
+        assert!(app.apply_namespaces(
+            "ctx-a",
+            &["live-ns".to_string()],
+            &NamespaceOrigin::Probed(probed.to_vec())
+        ));
+        assert_eq!(
+            app.available_namespaces,
+            vec!["default", "live-ns", "manual-ns"]
+        );
+    }
+
+    #[tokio::test]
+    async fn authoritative_replace_keeps_current_even_if_rejected() {
+        let mut app = App::new_test();
+        app.current_context = "ctx-a".into();
+        app.current_namespace = "rejected-ns".into();
+        let probed = ["live-ns".to_string(), "rejected-ns".to_string()];
+        assert!(app.apply_namespaces(
+            "ctx-a",
+            &["live-ns".to_string()],
+            &NamespaceOrigin::Probed(probed.to_vec())
+        ));
+        assert_eq!(app.available_namespaces, vec!["live-ns", "rejected-ns"]);
+    }
+
+    #[tokio::test]
+    async fn non_authoritative_namespaces_keep_existing() {
+        let mut app = App::new_test();
+        app.current_context = "ctx-a".into();
+        app.app_state.add_namespace("ctx-a", "old-ns");
+        assert!(app.apply_namespaces("ctx-a", &["new-ns".to_string()], &NamespaceOrigin::Listed));
+        assert_eq!(app.available_namespaces, vec!["new-ns", "old-ns"]);
+    }
+
+    #[tokio::test]
+    async fn single_namespace_is_selected_automatically() {
+        let mut app = App::new_test();
+        app.current_context = "ctx-a".into();
+        app.current_namespace = String::new();
+        app.apply_namespaces("ctx-a", &["team-a".to_string()], &NamespaceOrigin::Listed);
+        assert_eq!(app.current_namespace, "team-a");
+        assert_eq!(app.mode, AppMode::List);
+        assert_eq!(app.app_state.last_namespace("ctx-a"), None);
+    }
+
+    #[tokio::test]
+    async fn default_is_selected_when_present_among_many() {
+        let mut app = App::new_test();
+        app.current_context = "ctx-a".into();
+        app.current_namespace = String::new();
+        app.apply_namespaces(
+            "ctx-a",
+            &["default".to_string(), "kube-system".to_string()],
+            &NamespaceOrigin::Listed,
+        );
+        assert_eq!(app.current_namespace, "default");
+        assert_eq!(app.mode, AppMode::List);
+    }
+
+    #[tokio::test]
+    async fn several_namespaces_without_default_open_the_picker() {
+        let mut app = App::new_test();
+        app.current_context = "ctx-a".into();
+        app.current_namespace = String::new();
+        app.apply_namespaces(
+            "ctx-a",
+            &["team-a".to_string(), "team-b".to_string()],
+            &NamespaceOrigin::Listed,
+        );
+        assert!(!app.has_namespace());
+        assert_eq!(app.mode, AppMode::NamespaceSelect);
+        assert_eq!(app.filtered_namespaces, vec!["team-a", "team-b"]);
+    }
+
+    #[tokio::test]
+    async fn unverified_list_never_auto_selects() {
+        let mut app = App::new_test();
+        app.current_context = "ctx-a".into();
+        app.current_namespace = String::new();
+        app.apply_namespaces(
+            "ctx-a",
+            &["team-a".to_string()],
+            &NamespaceOrigin::Unverified,
+        );
+        assert!(!app.has_namespace());
+        assert_eq!(app.mode, AppMode::NamespaceSelect);
+    }
+
+    #[tokio::test]
+    async fn unverified_list_with_default_never_auto_selects() {
+        let mut app = App::new_test();
+        app.current_context = "ctx-a".into();
+        app.current_namespace = String::new();
+        app.apply_namespaces(
+            "ctx-a",
+            &["default".to_string(), "team-a".to_string()],
+            &NamespaceOrigin::Unverified,
+        );
+        assert!(!app.has_namespace());
+        assert_eq!(app.mode, AppMode::NamespaceSelect);
+    }
+
+    #[tokio::test]
+    async fn probed_list_auto_selects() {
+        let mut app = App::new_test();
+        app.current_context = "ctx-a".into();
+        app.current_namespace = String::new();
+        let probed = ["team-a".to_string()];
+        app.apply_namespaces(
+            "ctx-a",
+            &["team-a".to_string()],
+            &NamespaceOrigin::Probed(probed.to_vec()),
+        );
+        assert_eq!(app.current_namespace, "team-a");
+    }
+
+    #[tokio::test]
+    async fn skipped_prompt_is_rearmed() {
+        let mut app = App::new_test();
+        app.current_context = "ctx-a".into();
+        app.current_namespace = String::new();
+        app.mode = AppMode::LogView;
+        app.apply_namespaces(
+            "ctx-a",
+            &["team-a".to_string(), "team-b".to_string()],
+            &NamespaceOrigin::Listed,
+        );
+        assert!(app.namespace_prompt_pending);
+        app.mode = AppMode::List;
+        app.prompt_for_namespace();
+        assert_eq!(app.mode, AppMode::NamespaceSelect);
+        assert!(!app.namespace_prompt_pending);
+    }
+
+    #[tokio::test]
+    async fn empty_namespace_list_leaves_namespace_unset() {
+        let mut app = App::new_test();
+        app.current_context = "ctx-a".into();
+        app.current_namespace = String::new();
+        app.apply_namespaces("ctx-a", &[], &NamespaceOrigin::Listed);
+        assert!(!app.has_namespace());
+        assert_eq!(app.mode, AppMode::List);
+    }
+
+    #[tokio::test]
+    async fn existing_namespace_is_never_reresolved() {
+        let mut app = App::new_test();
+        app.current_context = "ctx-a".into();
+        app.current_namespace = "team-b".into();
+        app.apply_namespaces(
+            "ctx-a",
+            &["default".to_string(), "team-a".to_string()],
+            &NamespaceOrigin::Listed,
+        );
+        assert_eq!(app.current_namespace, "team-b");
+        assert_eq!(app.mode, AppMode::List);
+    }
+
+    #[tokio::test]
+    async fn picker_is_suppressed_outside_list_mode() {
+        let mut app = App::new_test();
+        app.current_context = "ctx-a".into();
+        app.current_namespace = String::new();
+        app.mode = AppMode::LogView;
+        app.apply_namespaces(
+            "ctx-a",
+            &["team-a".to_string(), "team-b".to_string()],
+            &NamespaceOrigin::Listed,
+        );
+        assert_eq!(app.mode, AppMode::LogView);
+        assert!(!app.has_namespace());
+    }
+
+    #[tokio::test]
+    async fn unavailable_teleport_adds_no_entries() {
+        let mut app = App::new_test();
+        app.teleport = TeleportState::Unavailable;
+        assert_eq!(app.context_entry_count(), 2);
+        assert_eq!(app.context_entry(2), None);
+    }
+
+    #[tokio::test]
+    async fn context_entry_never_panics_out_of_range() {
+        let mut app = App::new_test();
+        app.teleport = TeleportState::Available(vec!["k8s.a".into()]);
+        for i in 0..10 {
+            let _ = app.context_entry(i);
+        }
+        app.available_contexts.clear();
+        for i in 0..10 {
+            let _ = app.context_entry(i);
+        }
     }
 }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -14,13 +14,14 @@ use crate::ui::draw;
 use kube::runtime::watcher;
 
 fn is_forbidden(err: &watcher::Error) -> bool {
+    use crate::k8s::access::is_access_denied;
     match err {
         watcher::Error::InitialListFailed(e)
         | watcher::Error::WatchStartFailed(e)
         | watcher::Error::WatchFailed(e) => {
-            matches!(e, kube::Error::Api(resp) if resp.is_forbidden())
+            matches!(e, kube::Error::Api(resp) if is_access_denied(resp))
         }
-        watcher::Error::WatchError(resp) => resp.is_forbidden(),
+        watcher::Error::WatchError(resp) => is_access_denied(resp),
         _ => false,
     }
 }
@@ -91,7 +92,7 @@ fn ensure_watcher(
     watcher_active: &mut [bool; 3],
 ) {
     let idx = tab.index();
-    if watcher_active[idx] || app.tab_forbidden[idx] {
+    if watcher_active[idx] || app.tab_forbidden[idx] || !app.has_namespace() {
         return;
     }
     let stream = create_watcher_for_tab(app, tab);
@@ -187,10 +188,23 @@ fn handle_channel_event(app: &mut App, event: KubeResourceEvent) {
             app.describe_hscroll = 0;
             app.mode = AppMode::DescribeView;
         }
-        KubeResourceEvent::NamespacesLoaded(namespaces) => {
-            let ctx = app.current_context.clone();
-            app.available_namespaces = app.app_state.merge_namespaces(&ctx, &namespaces);
-            app.app_state.save();
+        KubeResourceEvent::NamespacesLoaded {
+            context,
+            namespaces,
+            origin,
+        } => {
+            if app.apply_namespaces(&context, &namespaces, &origin) {
+                app.app_state.save();
+            }
+        }
+        KubeResourceEvent::TeleportState(state) => {
+            app.teleport = state;
+            if app.mode == AppMode::ContextSelect
+                && let Some(i) = app.popup_state.selected()
+            {
+                app.popup_state
+                    .select(Some(i.min(app.context_entry_count().saturating_sub(1))));
+            }
         }
         KubeResourceEvent::PortForwardStopped { id, error } => {
             let user_stopped = app.port_forward_stopped_ids.remove(&id);
@@ -228,13 +242,14 @@ pub async fn run<B: Backend<Error: Send + Sync + 'static> + std::io::Write>(
     }
 
     app.available_namespaces = app.app_state.get_namespaces(&app.current_context);
-    if !app.available_namespaces.contains(&app.current_namespace) {
+    if app.has_namespace() && !app.available_namespaces.contains(&app.current_namespace) {
         app.available_namespaces.push(app.current_namespace.clone());
         app.available_namespaces.sort();
     }
 
     app.refresh_items();
     app.load_namespaces();
+    app.load_teleport_clusters();
 
     let mut current_ctx = app.current_context.clone();
 
@@ -250,16 +265,42 @@ pub async fn run<B: Backend<Error: Send + Sync + 'static> + std::io::Write>(
             return Ok(());
         }
 
-        if let Some(new_ctx) = app.pending_context.take() {
+        if app.pending_context.is_some() || app.pending_teleport_login.is_some() {
             crossterm::terminal::disable_raw_mode()?;
             crossterm::execute!(
                 terminal.backend_mut(),
                 crossterm::terminal::LeaveAlternateScreen,
                 crossterm::cursor::Show
             )?;
-            eprintln!("Authenticating with context '{new_ctx}'...");
 
-            let result = crate::k8s::config::create_client_with_context(&new_ctx).await;
+            let mut login_error = None;
+            let teleport_attempted = app.pending_teleport_login.is_some();
+            if let Some(login) = app.pending_teleport_login.take() {
+                match &login {
+                    crate::k8s::teleport::Login::Profile => {
+                        eprintln!("Logging into Teleport...")
+                    }
+                    crate::k8s::teleport::Login::KubeCluster(cluster) => {
+                        eprintln!("Logging into Teleport cluster '{cluster}'...")
+                    }
+                }
+                match tokio::task::spawn_blocking(move || crate::k8s::teleport::log_in(&login))
+                    .await
+                {
+                    Ok(Ok(ctx)) => app.pending_context = ctx,
+                    Ok(Err(e)) => login_error = Some(format!("Teleport login failed: {e}")),
+                    Err(e) => login_error = Some(format!("Teleport login failed: {e}")),
+                }
+            }
+
+            let switch = match app.pending_context.take() {
+                Some(new_ctx) => {
+                    eprintln!("Authenticating with context '{new_ctx}'...");
+                    let result = crate::k8s::config::create_client_with_context(&new_ctx).await;
+                    Some((new_ctx, result))
+                }
+                None => None,
+            };
 
             crossterm::execute!(
                 terminal.backend_mut(),
@@ -269,23 +310,48 @@ pub async fn run<B: Backend<Error: Send + Sync + 'static> + std::io::Write>(
             crossterm::terminal::enable_raw_mode()?;
             terminal.clear()?;
 
-            match result {
-                Ok(client) => {
-                    app.stop_all_port_forwards();
-                    app.client = client;
-                    app.current_namespace = crate::k8s::config::get_namespace_for_context_async(new_ctx.clone()).await;
-                    app.current_context = new_ctx.clone();
+            if let Some(err) = login_error {
+                app.set_error(err);
+            }
 
-                    app.available_namespaces = app.app_state.get_namespaces(&new_ctx);
-                    if !app.available_namespaces.contains(&app.current_namespace) {
-                        app.available_namespaces.push(app.current_namespace.clone());
-                        app.available_namespaces.sort();
+            let mut switched = false;
+            if let Some((new_ctx, result)) = switch {
+                match result {
+                    Ok(client) => {
+                        app.stop_all_port_forwards();
+                        app.client = client;
+                        let remembered = app
+                            .app_state
+                            .last_namespace(&new_ctx)
+                            .map(str::to_string)
+                            .or(crate::k8s::config::configured_namespace_for_context_async(
+                                new_ctx.clone(),
+                            )
+                            .await);
+                        app.current_namespace = remembered.unwrap_or_default();
+                        app.current_context = new_ctx.clone();
+
+                        app.available_namespaces = app.app_state.get_namespaces(&new_ctx);
+                        if app.has_namespace()
+                            && !app.available_namespaces.contains(&app.current_namespace)
+                        {
+                            app.available_namespaces.push(app.current_namespace.clone());
+                            app.available_namespaces.sort();
+                        }
+                        app.load_namespaces();
+                        switched = true;
                     }
-                    app.load_namespaces();
+                    Err(e) => {
+                        app.set_error(format!("Context switch failed: {e}"));
+                    }
                 }
-                Err(e) => {
-                    app.set_error(format!("Context switch failed: {e}"));
+            }
+
+            if teleport_attempted || switched {
+                if let Some(ctxs) = crate::k8s::config::list_contexts_async().await {
+                    app.available_contexts = ctxs;
                 }
+                app.load_teleport_clusters();
             }
             app.dirty = true;
         }
@@ -345,6 +411,9 @@ pub async fn run<B: Backend<Error: Send + Sync + 'static> + std::io::Write>(
             Some(Ok(event)) = reader.next() => {
                if let Event::Key(key) = event {
                    handle_input(&mut app, key);
+                   if app.namespace_prompt_pending && !app.has_namespace() {
+                       app.prompt_for_namespace();
+                   }
                    app.dirty = true;
                }
             }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,8 @@
 use crate::app::{App, LOG_CHROME_LINES};
-use crate::models::{AppMode, KubeResource, KubeResourceEvent, PendingAction, ResourceType};
+use crate::k8s::teleport::Login as TeleportLogin;
+use crate::models::{
+    AppMode, ContextEntry, KubeResource, KubeResourceEvent, PendingAction, ResourceType,
+};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use std::collections::HashSet;
 
@@ -25,16 +28,26 @@ pub fn handle_input(app: &mut App, key: KeyEvent) {
 }
 
 fn handle_popup_input(app: &mut App, key: KeyEvent) {
-    let len = app.available_contexts.len();
+    let len = app.context_entry_count();
     match key.code {
         KeyCode::Esc => {
             app.mode = AppMode::List;
         }
         KeyCode::Enter => {
-            if let Some(i) = app.popup_state.selected()
-                && let Some(ctx) = app.available_contexts.get(i)
-            {
-                app.pending_context = Some(ctx.clone());
+            if let Some(i) = app.popup_state.selected() {
+                match app.context_entry(i) {
+                    Some(ContextEntry::Kubeconfig(ctx)) => {
+                        app.pending_context = Some(ctx.to_string());
+                    }
+                    Some(ContextEntry::Teleport(cluster)) => {
+                        app.pending_teleport_login =
+                            Some(TeleportLogin::KubeCluster(cluster.to_string()));
+                    }
+                    Some(ContextEntry::TeleportLogin) => {
+                        app.pending_teleport_login = Some(TeleportLogin::Profile);
+                    }
+                    None => {}
+                }
             }
             app.mode = AppMode::List;
         }
@@ -73,6 +86,7 @@ fn select_namespace(app: &mut App, ns: String) {
         app.current_namespace = ns.clone();
         let ctx = app.current_context.clone();
         app.app_state.add_namespace(&ctx, &ns);
+        app.app_state.set_last_namespace(&ctx, &ns);
         if !app.available_namespaces.contains(&ns) {
             app.available_namespaces.push(ns);
             app.available_namespaces.sort();
@@ -534,6 +548,7 @@ fn handle_global_input(app: &mut App, key: KeyEvent) {
                 .position(|ctx| *ctx == app.current_context);
             app.popup_state.select(current_idx.or(Some(0)));
             app.mode = AppMode::ContextSelect;
+            app.load_teleport_clusters();
         }
         KeyCode::Char('n') => {
             app.namespace_input.clear();
@@ -1241,6 +1256,7 @@ fn prev_row(app: &mut App) {
 mod tests {
     use super::*;
     use crate::app::App;
+    use crate::k8s::teleport::State as TeleportState;
     use crate::models::{AppMode, KubeResource, PendingAction, ResourceType};
     use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
     use k8s_openapi::api::{apps::v1::Deployment, core::v1::Pod};
@@ -1377,6 +1393,65 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn context_popup_enter_selects_kubeconfig_context() {
+        let mut app = App::new_test();
+        app.teleport = TeleportState::Available(vec!["k8s.a".into()]);
+        app.mode = AppMode::ContextSelect;
+        app.popup_state.select(Some(1));
+        handle_input(&mut app, key(KeyCode::Enter));
+        assert_eq!(app.pending_context.as_deref(), Some("ctx2"));
+        assert!(app.pending_teleport_login.is_none());
+    }
+
+    #[tokio::test]
+    async fn context_popup_enter_selects_teleport_cluster() {
+        let mut app = App::new_test();
+        app.teleport = TeleportState::Available(vec!["k8s.a".into(), "k8s.b".into()]);
+        app.mode = AppMode::ContextSelect;
+        app.popup_state.select(Some(3));
+        handle_input(&mut app, key(KeyCode::Enter));
+        assert_eq!(
+            app.pending_teleport_login,
+            Some(TeleportLogin::KubeCluster("k8s.b".into()))
+        );
+        assert!(app.pending_context.is_none());
+        assert_eq!(app.mode, AppMode::List);
+    }
+
+    #[tokio::test]
+    async fn context_popup_navigation_spans_teleport_entries() {
+        let mut app = App::new_test();
+        app.teleport = TeleportState::Available(vec!["k8s.a".into()]);
+        app.mode = AppMode::ContextSelect;
+        app.popup_state.select(Some(0));
+        for _ in 0..5 {
+            handle_input(&mut app, key(KeyCode::Char('j')));
+        }
+        assert_eq!(app.popup_state.selected(), Some(2));
+    }
+
+    #[tokio::test]
+    async fn context_popup_enter_triggers_teleport_login() {
+        let mut app = App::new_test();
+        app.teleport = TeleportState::NeedsLogin;
+        app.mode = AppMode::ContextSelect;
+        app.popup_state.select(Some(2));
+        handle_input(&mut app, key(KeyCode::Enter));
+        assert_eq!(app.pending_teleport_login, Some(TeleportLogin::Profile));
+        assert!(app.pending_context.is_none());
+    }
+
+    #[tokio::test]
+    async fn context_popup_enter_out_of_range_is_noop() {
+        let mut app = App::new_test();
+        app.mode = AppMode::ContextSelect;
+        app.popup_state.select(Some(99));
+        handle_input(&mut app, key(KeyCode::Enter));
+        assert!(app.pending_context.is_none());
+        assert!(app.pending_teleport_login.is_none());
+    }
+
+    #[tokio::test]
     async fn n_opens_namespace_select() {
         let mut app = App::new_test();
         handle_input(&mut app, key(KeyCode::Char('n')));
@@ -1451,6 +1526,20 @@ mod tests {
         handle_input(&mut app, key(KeyCode::Enter));
         assert_eq!(app.current_namespace, "staging");
         assert_eq!(app.mode, AppMode::List);
+    }
+
+    #[tokio::test]
+    async fn selecting_namespace_remembers_it_and_clears_provisional() {
+        let mut app = App::new_test();
+        app.current_context = "ctx-a".into();
+        app.mode = AppMode::NamespaceSelect;
+        app.available_namespaces = vec!["team-a".into()];
+        app.filtered_namespaces = vec!["team-a".into()];
+        app.popup_state.select(Some(0));
+
+        handle_input(&mut app, key(KeyCode::Enter));
+        assert_eq!(app.current_namespace, "team-a");
+        assert_eq!(app.app_state.last_namespace("ctx-a"), Some("team-a"));
     }
 
     #[tokio::test]

--- a/src/k8s/access.rs
+++ b/src/k8s/access.rs
@@ -1,0 +1,263 @@
+use futures::StreamExt;
+use k8s_openapi::api::authorization::v1::{
+    ResourceRule, SelfSubjectRulesReview, SelfSubjectRulesReviewSpec, SubjectRulesReviewStatus,
+};
+use kube::api::PostParams;
+use kube::{Api, Client};
+
+const RELEVANT_RESOURCES: [&str; 3] = ["pods", "deployments", "secrets"];
+const PROBE_CONCURRENCY: usize = 32;
+
+pub fn is_access_denied(status: &kube::core::Status) -> bool {
+    status.is_forbidden()
+        || status.code == 403
+        || (status.code == 404 && status.message.contains("access denied"))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Relevance {
+    Filtered {
+        relevant: Vec<String>,
+        probed: Vec<String>,
+    },
+    Unfiltered(Vec<String>),
+}
+
+impl Relevance {
+    pub fn into_parts(self) -> (Vec<String>, crate::models::NamespaceOrigin) {
+        match self {
+            Relevance::Filtered { relevant, probed } => {
+                (relevant, crate::models::NamespaceOrigin::Probed(probed))
+            }
+            Relevance::Unfiltered(namespaces) => {
+                (namespaces, crate::models::NamespaceOrigin::Unverified)
+            }
+        }
+    }
+}
+
+pub fn grants_relevant_access(rules: &[ResourceRule]) -> bool {
+    rules.iter().any(|rule| {
+        let can_read = rule.verbs.iter().any(|v| v == "list" || v == "*");
+        let on_relevant = rule.resources.as_ref().is_some_and(|resources| {
+            resources
+                .iter()
+                .any(|r| r == "*" || RELEVANT_RESOURCES.contains(&r.as_str()))
+        });
+        can_read && on_relevant
+    })
+}
+
+pub fn status_is_relevant(status: &SubjectRulesReviewStatus) -> bool {
+    status.incomplete || grants_relevant_access(&status.resource_rules)
+}
+
+async fn is_namespace_relevant(client: Client, namespace: String) -> Option<String> {
+    let review = SelfSubjectRulesReview {
+        spec: SelfSubjectRulesReviewSpec {
+            namespace: Some(namespace.clone()),
+        },
+        ..Default::default()
+    };
+    let api: Api<SelfSubjectRulesReview> = Api::all(client);
+    match api.create(&PostParams::default(), &review).await {
+        Ok(result) => result.status.filter(status_is_relevant).map(|_| namespace),
+        Err(e) => {
+            tracing::debug!("rules review for '{namespace}' failed: {e}");
+            None
+        }
+    }
+}
+
+pub async fn filter_relevant(client: &Client, candidates: Vec<String>) -> Relevance {
+    if candidates.is_empty() {
+        return Relevance::Unfiltered(candidates);
+    }
+    let total = candidates.len();
+    let mut relevant: Vec<String> = futures::stream::iter(candidates.clone())
+        .map(|ns| is_namespace_relevant(client.clone(), ns))
+        .buffer_unordered(PROBE_CONCURRENCY)
+        .filter_map(std::future::ready)
+        .collect()
+        .await;
+
+    if relevant.is_empty() {
+        tracing::warn!("no namespace passed the access probe, keeping all {total} candidates");
+        return Relevance::Unfiltered(candidates);
+    }
+    relevant.sort();
+    tracing::info!(
+        "{}/{total} namespaces relevant for this cluster",
+        relevant.len()
+    );
+    Relevance::Filtered {
+        relevant,
+        probed: candidates,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rule(resources: &[&str], verbs: &[&str]) -> ResourceRule {
+        ResourceRule {
+            resources: Some(resources.iter().map(|r| r.to_string()).collect()),
+            verbs: verbs.iter().map(|v| v.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    fn baseline() -> Vec<ResourceRule> {
+        vec![
+            rule(
+                &["selfsubjectaccessreviews.authorization.k8s.io"],
+                &["create"],
+            ),
+            rule(
+                &["selfsubjectrulesreviews.authorization.k8s.io"],
+                &["create"],
+            ),
+        ]
+    }
+
+    fn status_code(code: u16, message: &str) -> kube::core::Status {
+        kube::core::Status {
+            code,
+            message: message.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn plain_403_is_access_denied() {
+        assert!(is_access_denied(&status_code(403, "pods is forbidden")));
+    }
+
+    #[test]
+    fn forbidden_reason_is_access_denied() {
+        let status = kube::core::Status {
+            reason: "Forbidden".to_string(),
+            ..status_code(0, "")
+        };
+        assert!(is_access_denied(&status));
+    }
+
+    #[test]
+    fn teleport_404_access_denied_is_access_denied() {
+        assert!(is_access_denied(&status_code(
+            404,
+            "Unable to list \"/v1, Resource=pods\": access denied\n\trole some-role is not found"
+        )));
+    }
+
+    #[test]
+    fn genuine_404_is_not_access_denied() {
+        assert!(!is_access_denied(&status_code(
+            404,
+            "namespaces \"nope\" not found"
+        )));
+    }
+
+    #[test]
+    fn other_codes_are_not_access_denied() {
+        assert!(!is_access_denied(&status_code(401, "access denied")));
+        assert!(!is_access_denied(&status_code(500, "internal error")));
+    }
+
+    #[test]
+    fn baseline_rules_are_not_relevant() {
+        assert!(!grants_relevant_access(&baseline()));
+    }
+
+    #[test]
+    fn no_rules_is_not_relevant() {
+        assert!(!grants_relevant_access(&[]));
+    }
+
+    #[test]
+    fn pod_list_access_is_relevant() {
+        let mut rules = baseline();
+        rules.push(rule(&["pods"], &["get", "list", "watch"]));
+        assert!(grants_relevant_access(&rules));
+    }
+
+    #[test]
+    fn secrets_and_deployments_count_as_relevant() {
+        assert!(grants_relevant_access(&[rule(&["secrets"], &["list"])]));
+        assert!(grants_relevant_access(&[rule(&["deployments"], &["list"])]));
+    }
+
+    #[test]
+    fn wildcards_are_relevant() {
+        assert!(grants_relevant_access(&[rule(&["*"], &["*"])]));
+        assert!(grants_relevant_access(&[rule(&["pods"], &["*"])]));
+        assert!(grants_relevant_access(&[rule(&["*"], &["list"])]));
+    }
+
+    #[test]
+    fn write_only_access_is_not_relevant() {
+        assert!(!grants_relevant_access(&[rule(
+            &["pods"],
+            &["create", "delete"]
+        )]));
+    }
+
+    #[test]
+    fn unrelated_resources_are_not_relevant() {
+        assert!(!grants_relevant_access(&[rule(&["configmaps"], &["list"])]));
+    }
+
+    fn status(rules: Vec<ResourceRule>, incomplete: bool) -> SubjectRulesReviewStatus {
+        SubjectRulesReviewStatus {
+            resource_rules: rules,
+            incomplete,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn incomplete_status_fails_open() {
+        assert!(status_is_relevant(&status(baseline(), true)));
+        assert!(!status_is_relevant(&status(baseline(), false)));
+    }
+
+    #[test]
+    fn complete_status_with_access_is_relevant() {
+        assert!(status_is_relevant(&status(
+            vec![rule(&["pods"], &["list"])],
+            false
+        )));
+    }
+
+    #[test]
+    fn relevance_into_parts_carries_probed_scope() {
+        let relevant = vec!["a".to_string()];
+        let probed = vec!["a".to_string(), "b".to_string()];
+        assert_eq!(
+            Relevance::Filtered {
+                relevant: relevant.clone(),
+                probed: probed.clone(),
+            }
+            .into_parts(),
+            (
+                relevant.clone(),
+                crate::models::NamespaceOrigin::Probed(probed)
+            )
+        );
+        assert_eq!(
+            Relevance::Unfiltered(relevant.clone()).into_parts(),
+            (relevant, crate::models::NamespaceOrigin::Unverified)
+        );
+    }
+
+    #[test]
+    fn rule_without_resources_is_not_relevant() {
+        let rule = ResourceRule {
+            resources: None,
+            verbs: vec!["list".to_string()],
+            ..Default::default()
+        };
+        assert!(!grants_relevant_access(&[rule]));
+    }
+}

--- a/src/k8s/config.rs
+++ b/src/k8s/config.rs
@@ -12,31 +12,26 @@ pub fn get_current_context() -> Result<String> {
     Ok(config.current_context.unwrap_or_default())
 }
 
-pub fn get_context_namespace() -> Result<String> {
+pub fn get_context_namespace() -> Result<Option<String>> {
     let config = Kubeconfig::read()?;
     let ctx_name = config.current_context.as_deref().unwrap_or_default();
-    let ns = config
+    Ok(config
         .contexts
         .iter()
         .find(|c| c.name == ctx_name)
         .and_then(|c| c.context.as_ref())
-        .and_then(|c| c.namespace.clone())
-        .unwrap_or_else(|| "default".to_string());
-    Ok(ns)
+        .and_then(|c| c.namespace.clone()))
 }
 
-pub fn get_namespace_for_context(context: &str) -> String {
-    Kubeconfig::read()
-        .ok()
-        .and_then(|config| {
-            config
-                .contexts
-                .iter()
-                .find(|c| c.name == context)
-                .and_then(|c| c.context.as_ref())
-                .and_then(|c| c.namespace.clone())
-        })
-        .unwrap_or_else(|| "default".to_string())
+pub fn configured_namespace_for_context(context: &str) -> Option<String> {
+    Kubeconfig::read().ok().and_then(|config| {
+        config
+            .contexts
+            .iter()
+            .find(|c| c.name == context)
+            .and_then(|c| c.context.as_ref())
+            .and_then(|c| c.namespace.clone())
+    })
 }
 
 pub async fn create_client_with_context(context: &str) -> Result<Client> {
@@ -49,10 +44,16 @@ pub async fn create_client_with_context(context: &str) -> Result<Client> {
     Ok(client)
 }
 
-pub async fn get_namespace_for_context_async(context: String) -> String {
-    tokio::task::spawn_blocking(move || {
-        get_namespace_for_context(&context)
-    })
-    .await
-    .unwrap_or_else(|_| "default".to_string())
+pub async fn list_contexts_async() -> Option<Vec<String>> {
+    tokio::task::spawn_blocking(|| list_contexts().ok())
+        .await
+        .ok()
+        .flatten()
+}
+
+pub async fn configured_namespace_for_context_async(context: String) -> Option<String> {
+    tokio::task::spawn_blocking(move || configured_namespace_for_context(&context))
+        .await
+        .ok()
+        .flatten()
 }

--- a/src/k8s/mod.rs
+++ b/src/k8s/mod.rs
@@ -1,4 +1,6 @@
+pub mod access;
 pub mod actions;
 pub mod client;
 pub mod config;
+pub mod teleport;
 pub mod watcher;

--- a/src/k8s/teleport.rs
+++ b/src/k8s/teleport.rs
@@ -1,0 +1,538 @@
+use anyhow::{Result, anyhow, bail};
+use kube::config::Kubeconfig;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+use tokio::sync::OnceCell;
+
+const TSH: &str = "tsh";
+const TSH_TIMEOUT: Duration = Duration::from_secs(10);
+const STATUS_TTL: Duration = Duration::from_secs(5);
+const NS_GROUP_PREFIX: &str = "teleport:ns:";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Profile {
+    pub cluster: String,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub enum State {
+    #[default]
+    Unavailable,
+    NeedsLogin,
+    Available(Vec<String>),
+}
+
+impl State {
+    pub fn clusters(&self) -> &[String] {
+        match self {
+            State::Available(clusters) => clusters,
+            _ => &[],
+        }
+    }
+
+    pub fn needs_login(&self) -> bool {
+        matches!(self, State::NeedsLogin)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Login {
+    Profile,
+    KubeCluster(String),
+}
+
+async fn capture(args: &[&str], routine_failure: bool) -> Option<String> {
+    let output = tokio::time::timeout(
+        TSH_TIMEOUT,
+        tokio::process::Command::new(TSH)
+            .args(args)
+            .stdin(Stdio::null())
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
+    .inspect_err(|_| tracing::warn!("tsh {} timed out after {TSH_TIMEOUT:?}", args.join(" ")))
+    .ok()?
+    .inspect_err(|e| tracing::warn!("tsh {} failed to spawn: {e}", args.join(" ")))
+    .ok()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if routine_failure {
+            tracing::debug!("tsh {} exited with {}", args.join(" "), output.status);
+        } else {
+            tracing::warn!(
+                "tsh {} exited with {}: {}",
+                args.join(" "),
+                output.status,
+                stderr.trim()
+            );
+        }
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+pub async fn is_installed() -> bool {
+    static INSTALLED: OnceCell<bool> = OnceCell::const_new();
+    if let Some(installed) = INSTALLED.get() {
+        return *installed;
+    }
+    match tokio::time::timeout(
+        TSH_TIMEOUT,
+        tokio::process::Command::new(TSH)
+            .args(["version", "--client"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .kill_on_drop(true)
+            .status(),
+    )
+    .await
+    {
+        Ok(Ok(status)) => {
+            let _ = INSTALLED.set(status.success());
+            status.success()
+        }
+        Ok(Err(e)) => {
+            tracing::debug!("tsh not available: {e}");
+            let _ = INSTALLED.set(false);
+            false
+        }
+        Err(_) => {
+            tracing::warn!("tsh version timed out after {TSH_TIMEOUT:?}, not caching");
+            false
+        }
+    }
+}
+
+pub fn parse_profile(json: &str) -> Option<Profile> {
+    let value: serde_json::Value = serde_json::from_str(json).ok()?;
+    let cluster = value
+        .get("active")?
+        .get("cluster")?
+        .as_str()
+        .filter(|c| !c.is_empty())?
+        .to_string();
+    Some(Profile { cluster })
+}
+
+static STATUS_CACHE: tokio::sync::Mutex<Option<(u64, std::time::Instant, String)>> =
+    tokio::sync::Mutex::const_new(None);
+static STATUS_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+pub fn invalidate_status_cache() {
+    STATUS_GENERATION.fetch_add(1, Ordering::Relaxed);
+}
+
+async fn status_json() -> Option<String> {
+    let generation = STATUS_GENERATION.load(Ordering::Relaxed);
+    let mut cache = STATUS_CACHE.lock().await;
+    if let Some((cached_generation, fetched_at, json)) = cache.as_ref()
+        && *cached_generation == generation
+        && fetched_at.elapsed() < STATUS_TTL
+    {
+        return Some(json.clone());
+    }
+    let json = capture(&["status", "--format=json"], true).await?;
+    *cache = Some((generation, std::time::Instant::now(), json.clone()));
+    Some(json)
+}
+
+pub async fn active_profile() -> Option<Profile> {
+    parse_profile(&status_json().await?)
+}
+
+pub fn parse_namespaces(json: &str) -> Vec<String> {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(json) else {
+        return Vec::new();
+    };
+    let Some(groups) = value
+        .get("active")
+        .and_then(|a| a.get("kubernetes_groups"))
+        .and_then(|g| g.as_array())
+    else {
+        return Vec::new();
+    };
+    let mut namespaces: Vec<String> = groups
+        .iter()
+        .filter_map(|g| g.as_str())
+        .filter_map(|g| g.strip_prefix(NS_GROUP_PREFIX))
+        .map(|rest| rest.split(':').next().unwrap_or(rest))
+        .filter(|ns| !ns.is_empty())
+        .map(str::to_string)
+        .collect();
+    namespaces.sort();
+    namespaces.dedup();
+    namespaces
+}
+
+pub fn is_teleport_context(context: &str, profile_cluster: &str) -> bool {
+    context.len() > profile_cluster.len() + 1
+        && context.starts_with(profile_cluster)
+        && context.as_bytes()[profile_cluster.len()] == b'-'
+}
+
+pub async fn grantable_namespaces(context: &str) -> Vec<String> {
+    if !is_installed().await {
+        return Vec::new();
+    }
+    let Some(json) = status_json().await else {
+        return Vec::new();
+    };
+    let Some(profile) = parse_profile(&json) else {
+        return Vec::new();
+    };
+    if !is_teleport_context(context, &profile.cluster) {
+        return Vec::new();
+    }
+    parse_namespaces(&json)
+}
+
+pub fn parse_kube_clusters(json: &str) -> Vec<String> {
+    let Ok(serde_json::Value::Array(items)) = serde_json::from_str::<serde_json::Value>(json)
+    else {
+        return Vec::new();
+    };
+    items
+        .iter()
+        .filter_map(|item| item.get("kube_cluster_name").and_then(|v| v.as_str()))
+        .filter(|name| !name.is_empty() && !name.starts_with('-'))
+        .map(str::to_string)
+        .collect()
+}
+
+pub async fn list_kube_clusters() -> Option<Vec<String>> {
+    capture(&["kube", "ls", "-f", "json"], false)
+        .await
+        .map(|json| parse_kube_clusters(&json))
+}
+
+pub fn context_name(profile_cluster: &str, kube_cluster: &str) -> String {
+    format!("{profile_cluster}-{kube_cluster}")
+}
+
+pub fn missing_clusters(all: &[String], contexts: &[String], profile_cluster: &str) -> Vec<String> {
+    let prefix = format!("{profile_cluster}-");
+    let mut missing: Vec<String> = all
+        .iter()
+        .filter(|cluster| {
+            !contexts
+                .iter()
+                .any(|ctx| ctx.strip_prefix(prefix.as_str()) == Some(cluster.as_str()))
+        })
+        .cloned()
+        .collect();
+    missing.sort();
+    missing
+}
+
+pub fn compose_state(
+    profile: Option<&Profile>,
+    all: Option<&[String]>,
+    contexts: &[String],
+    profile_on_disk: bool,
+) -> State {
+    match profile {
+        None if profile_on_disk => State::NeedsLogin,
+        None => State::Unavailable,
+        Some(profile) => State::Available(missing_clusters(
+            all.unwrap_or_default(),
+            contexts,
+            &profile.cluster,
+        )),
+    }
+}
+
+pub async fn probe() -> State {
+    if !is_installed().await {
+        return State::Unavailable;
+    }
+    let profile = active_profile().await;
+    let all = match profile {
+        Some(_) => list_kube_clusters().await,
+        None => None,
+    };
+    let contexts = read_context_names().await;
+    compose_state(
+        profile.as_ref(),
+        all.as_deref(),
+        &contexts,
+        has_profile_on_disk(),
+    )
+}
+
+async fn read_context_names() -> Vec<String> {
+    tokio::task::spawn_blocking(|| {
+        Kubeconfig::read()
+            .map(|c| c.contexts.into_iter().map(|c| c.name).collect())
+            .unwrap_or_default()
+    })
+    .await
+    .unwrap_or_default()
+}
+
+fn has_profile_on_disk() -> bool {
+    dirs::home_dir()
+        .map(|h| h.join(".tsh").join("current-profile").exists())
+        .unwrap_or(false)
+}
+
+pub fn kube_login_args(cluster: &str) -> [&str; 4] {
+    ["kube", "login", "--disable-access-request", cluster]
+}
+
+fn run_interactive(args: &[&str]) -> Result<()> {
+    let spawned = Command::new(TSH).args(args).status();
+    invalidate_status_cache();
+    let status = spawned?;
+    if !status.success() {
+        bail!("tsh {} exited with {status}", args.join(" "));
+    }
+    Ok(())
+}
+
+pub fn log_in(login: &Login) -> Result<Option<String>> {
+    let cluster = match login {
+        Login::Profile => {
+            run_interactive(&["login"])?;
+            return Ok(None);
+        }
+        Login::KubeCluster(cluster) => cluster.as_str(),
+    };
+
+    if cluster.starts_with('-') {
+        bail!("refusing suspicious cluster name '{cluster}'");
+    }
+
+    let profile = match blocking_profile() {
+        Some(profile) => profile,
+        None => {
+            eprintln!("Teleport session expired, running 'tsh login'...");
+            run_interactive(&["login"])?;
+            blocking_profile().ok_or_else(|| anyhow!("no active Teleport profile after login"))?
+        }
+    };
+
+    run_interactive(&kube_login_args(cluster))?;
+    let config = Kubeconfig::read()?;
+    resolve_context(&config, &profile.cluster, cluster).map(Some)
+}
+
+fn blocking_profile() -> Option<Profile> {
+    let output = Command::new(TSH)
+        .args(["status", "--format=json"])
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_profile(&String::from_utf8_lossy(&output.stdout))
+}
+
+pub fn resolve_context(
+    config: &Kubeconfig,
+    profile_cluster: &str,
+    kube_cluster: &str,
+) -> Result<String> {
+    let expected = context_name(profile_cluster, kube_cluster);
+    if config.contexts.iter().any(|c| c.name == expected) {
+        return Ok(expected);
+    }
+    config
+        .current_context
+        .clone()
+        .ok_or_else(|| anyhow!("context for '{kube_cluster}' not found in kubeconfig"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn profile(cluster: &str) -> Profile {
+        Profile {
+            cluster: cluster.to_string(),
+        }
+    }
+
+    #[test]
+    fn parses_active_profile() {
+        let json = r#"{"active":{"profile_url":"https://teleport.example.com:443","cluster":"teleport-example"}}"#;
+        assert_eq!(parse_profile(json).unwrap().cluster, "teleport-example");
+    }
+
+    #[test]
+    fn no_profile_when_inactive() {
+        assert!(parse_profile(r#"{"active":null}"#).is_none());
+        assert!(parse_profile(r#"{"active":{"cluster":""}}"#).is_none());
+        assert!(parse_profile(r#"{}"#).is_none());
+        assert!(parse_profile("not json").is_none());
+    }
+
+    #[test]
+    fn parses_namespaces_from_groups() {
+        let json = r#"{"active":{"kubernetes_groups":[
+            "teleport:ns:team-a:readwrite",
+            "teleport:ns:team-a:secret:readonly",
+            "teleport:ns:team-b:readwrite"
+        ]}}"#;
+        assert_eq!(parse_namespaces(json), vec!["team-a", "team-b"]);
+    }
+
+    #[test]
+    fn ignores_non_namespace_groups() {
+        let json = r#"{"active":{"kubernetes_groups":["system:masters","teleport:ns:a:readwrite","teleport:ns::x"]}}"#;
+        assert_eq!(parse_namespaces(json), vec!["a"]);
+    }
+
+    #[test]
+    fn no_namespaces_without_groups() {
+        assert!(parse_namespaces(r#"{"active":{}}"#).is_empty());
+        assert!(parse_namespaces(r#"{}"#).is_empty());
+        assert!(parse_namespaces("not json").is_empty());
+    }
+
+    #[test]
+    fn parses_kube_clusters() {
+        let json = r#"[{"kube_cluster_name":"k8s.a","selected":false},{"kube_cluster_name":"k8s.b","selected":true}]"#;
+        assert_eq!(parse_kube_clusters(json), vec!["k8s.a", "k8s.b"]);
+    }
+
+    #[test]
+    fn rejects_flag_like_cluster_names() {
+        let json = r#"[{"kube_cluster_name":"--insecure"},{"kube_cluster_name":""},{"kube_cluster_name":"k8s.ok"}]"#;
+        assert_eq!(parse_kube_clusters(json), vec!["k8s.ok"]);
+    }
+
+    #[test]
+    fn empty_kube_clusters_on_bad_json() {
+        assert!(parse_kube_clusters("{}").is_empty());
+        assert!(parse_kube_clusters("").is_empty());
+    }
+
+    #[test]
+    fn kube_login_always_disables_access_requests() {
+        let args = kube_login_args("k8s.alpha");
+        assert!(
+            args.contains(&"--disable-access-request"),
+            "tsh kube login files a server-side access request by default; \
+             selecting a row in a TUI list must never do that"
+        );
+        assert_eq!(args.last(), Some(&"k8s.alpha"));
+    }
+
+    #[test]
+    fn builds_context_name() {
+        assert_eq!(
+            context_name("teleport-example", "k8s.alpha"),
+            "teleport-example-k8s.alpha"
+        );
+    }
+
+    #[test]
+    fn recognizes_teleport_contexts() {
+        assert!(is_teleport_context(
+            "teleport-example-k8s.alpha",
+            "teleport-example"
+        ));
+        assert!(!is_teleport_context("docker-desktop", "teleport-example"));
+        assert!(!is_teleport_context("teleport-example", "teleport-example"));
+        assert!(!is_teleport_context(
+            "teleport-example-",
+            "teleport-example"
+        ));
+        assert!(!is_teleport_context(
+            "teleport-examplex-a",
+            "teleport-example"
+        ));
+    }
+
+    #[test]
+    fn computes_missing_clusters() {
+        let all = vec![
+            "k8s.beta".to_string(),
+            "k8s.alpha".to_string(),
+            "k8s.gamma".to_string(),
+        ];
+        let contexts = vec!["teleport-example-k8s.alpha".to_string()];
+        assert_eq!(
+            missing_clusters(&all, &contexts, "teleport-example"),
+            vec!["k8s.beta", "k8s.gamma"]
+        );
+    }
+
+    #[test]
+    fn no_missing_when_all_logged_in() {
+        let all = vec!["k8s.a".to_string()];
+        let contexts = vec!["tp-k8s.a".to_string()];
+        assert!(missing_clusters(&all, &contexts, "tp").is_empty());
+    }
+
+    #[test]
+    fn compose_state_needs_login_only_with_profile_on_disk() {
+        assert_eq!(compose_state(None, None, &[], true), State::NeedsLogin);
+        assert_eq!(compose_state(None, None, &[], false), State::Unavailable);
+    }
+
+    #[test]
+    fn compose_state_available_lists_missing() {
+        let all = vec!["k8s.a".to_string(), "k8s.b".to_string()];
+        let contexts = vec!["tp-k8s.a".to_string()];
+        let state = compose_state(Some(&profile("tp")), Some(&all), &contexts, true);
+        assert_eq!(state, State::Available(vec!["k8s.b".to_string()]));
+        assert_eq!(state.clusters(), ["k8s.b"]);
+        assert!(!state.needs_login());
+    }
+
+    #[test]
+    fn compose_state_available_with_failed_listing() {
+        let state = compose_state(Some(&profile("tp")), None, &[], true);
+        assert_eq!(state, State::Available(Vec::new()));
+    }
+
+    #[test]
+    fn state_accessors_on_unavailable() {
+        assert!(State::Unavailable.clusters().is_empty());
+        assert!(!State::Unavailable.needs_login());
+        assert!(State::NeedsLogin.needs_login());
+        assert!(State::NeedsLogin.clusters().is_empty());
+    }
+
+    fn kubeconfig_with(contexts: &[&str], current: Option<&str>) -> Kubeconfig {
+        Kubeconfig {
+            contexts: contexts
+                .iter()
+                .map(|name| kube::config::NamedContext {
+                    name: name.to_string(),
+                    context: None,
+                })
+                .collect(),
+            current_context: current.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn resolve_context_prefers_expected_name() {
+        let config = kubeconfig_with(&["tp-k8s.a", "other"], Some("other"));
+        assert_eq!(resolve_context(&config, "tp", "k8s.a").unwrap(), "tp-k8s.a");
+    }
+
+    #[test]
+    fn resolve_context_falls_back_to_current() {
+        let config = kubeconfig_with(&["custom-name"], Some("custom-name"));
+        assert_eq!(
+            resolve_context(&config, "tp", "k8s.a").unwrap(),
+            "custom-name"
+        );
+    }
+
+    #[test]
+    fn resolve_context_errors_without_current() {
+        let config = kubeconfig_with(&[], None);
+        assert!(resolve_context(&config, "tp", "k8s.a").is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,14 @@ struct Args {
     command: Option<String>,
 }
 
+const MAX_LOG_BYTES: u64 = 16 * 1024 * 1024;
+
+fn rotate_if_oversized(path: &std::path::Path) {
+    if std::fs::metadata(path).is_ok_and(|m| m.len() > MAX_LOG_BYTES) {
+        let _ = std::fs::rename(path, path.with_extension("log.1"));
+    }
+}
+
 fn init_tracing(to_file: bool) {
     let filter = tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         tracing_subscriber::EnvFilter::new("kr=info,kube=warn,hyper=warn,tower=warn,h2=warn")
@@ -43,10 +51,12 @@ fn init_tracing(to_file: bool) {
             .unwrap_or_else(|| std::path::PathBuf::from("."))
             .join("kr");
         let _ = std::fs::create_dir_all(&log_dir);
+        let log_path = log_dir.join("kr.log");
+        rotate_if_oversized(&log_path);
         if let Ok(file) = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
-            .open(log_dir.join("kr.log"))
+            .open(&log_path)
         {
             tracing_subscriber::fmt()
                 .with_env_filter(filter)

--- a/src/models.rs
+++ b/src/models.rs
@@ -107,8 +107,43 @@ pub enum KubeResourceEvent {
     ShellOutput(Vec<u8>),
     ShellExited,
     DescribeReady(Vec<String>),
-    NamespacesLoaded(Vec<String>),
-    PortForwardStopped { id: u64, error: Option<String> },
+    NamespacesLoaded {
+        context: String,
+        namespaces: Vec<String>,
+        origin: NamespaceOrigin,
+    },
+    TeleportState(crate::k8s::teleport::State),
+    PortForwardStopped {
+        id: u64,
+        error: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NamespaceOrigin {
+    Listed,
+    Probed(Vec<String>),
+    Unverified,
+}
+
+impl NamespaceOrigin {
+    pub fn is_verified(&self) -> bool {
+        !matches!(self, NamespaceOrigin::Unverified)
+    }
+
+    pub fn supersedes(&self) -> Option<&[String]> {
+        match self {
+            NamespaceOrigin::Probed(probed) => Some(probed),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContextEntry<'a> {
+    Kubeconfig(&'a str),
+    Teleport(&'a str),
+    TeleportLogin,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -6,6 +6,10 @@ use std::path::PathBuf;
 pub struct AppState {
     #[serde(default)]
     pub namespaces: HashMap<String, Vec<String>>,
+    #[serde(default)]
+    pub last_namespace: HashMap<String, String>,
+    #[serde(skip)]
+    pub no_persist: bool,
 }
 
 fn state_path() -> PathBuf {
@@ -25,6 +29,9 @@ impl AppState {
     }
 
     pub fn save(&self) {
+        if self.no_persist {
+            return;
+        }
         let path = state_path();
         if let Ok(json) = serde_json::to_string_pretty(self) {
             tokio::task::spawn_blocking(move || {
@@ -57,12 +64,39 @@ impl AppState {
         self.namespaces.get(context).cloned().unwrap_or_default()
     }
 
+    pub fn last_namespace(&self, context: &str) -> Option<&str> {
+        self.last_namespace.get(context).map(String::as_str)
+    }
+
+    pub fn set_last_namespace(&mut self, context: &str, namespace: &str) {
+        self.last_namespace
+            .insert(context.to_string(), namespace.to_string());
+    }
+
     pub fn add_namespace(&mut self, context: &str, namespace: &str) {
         let entry = self.namespaces.entry(context.to_string()).or_default();
         if !entry.contains(&namespace.to_string()) {
             entry.push(namespace.to_string());
             entry.sort();
         }
+    }
+
+    pub fn replace_namespaces(
+        &mut self,
+        context: &str,
+        discovered: &[String],
+        superseded: &[String],
+        keep: &str,
+    ) -> Vec<String> {
+        let entry = self.namespaces.entry(context.to_string()).or_default();
+        entry.retain(|ns| !superseded.contains(ns));
+        entry.extend(discovered.iter().cloned());
+        if !keep.is_empty() {
+            entry.push(keep.to_string());
+        }
+        entry.sort();
+        entry.dedup();
+        entry.clone()
     }
 
     pub fn merge_namespaces(&mut self, context: &str, discovered: &[String]) -> Vec<String> {
@@ -96,6 +130,66 @@ mod tests {
         state.add_namespace("ctx1", "saved-ns");
         let merged = state.merge_namespaces("ctx1", &["api-ns".into(), "saved-ns".into()]);
         assert_eq!(merged, vec!["api-ns", "saved-ns"]);
+    }
+
+    #[test]
+    fn replace_namespaces_drops_stale_entries() {
+        let mut state = AppState::default();
+        state.add_namespace("ctx1", "gone-ns");
+        state.add_namespace("ctx1", "still-ns");
+        let result =
+            state.replace_namespaces("ctx1", &["still-ns".into()], &["gone-ns".into()], "");
+        assert_eq!(result, vec!["still-ns"]);
+        assert_eq!(state.get_namespaces("ctx1"), vec!["still-ns"]);
+    }
+
+    #[test]
+    fn replace_namespaces_keeps_current() {
+        let mut state = AppState::default();
+        state.add_namespace("ctx1", "gone-ns");
+        let result =
+            state.replace_namespaces("ctx1", &["new-ns".into()], &["gone-ns".into()], "manual-ns");
+        assert_eq!(result, vec!["manual-ns", "new-ns"]);
+    }
+
+    #[test]
+    fn replace_namespaces_does_not_duplicate_current() {
+        let mut state = AppState::default();
+        let result = state.replace_namespaces("ctx1", &["ns-a".into()], &[], "ns-a");
+        assert_eq!(result, vec!["ns-a"]);
+    }
+
+    #[test]
+    fn replace_namespaces_isolates_contexts() {
+        let mut state = AppState::default();
+        state.add_namespace("ctx2", "other-ns");
+        state.replace_namespaces("ctx1", &["ns-a".into()], &[], "");
+        assert_eq!(state.get_namespaces("ctx2"), vec!["other-ns"]);
+    }
+
+    #[test]
+    fn last_namespace_roundtrips_per_context() {
+        let mut state = AppState::default();
+        assert!(state.last_namespace("ctx1").is_none());
+        state.set_last_namespace("ctx1", "ns-a");
+        state.set_last_namespace("ctx2", "ns-b");
+        assert_eq!(state.last_namespace("ctx1"), Some("ns-a"));
+        assert_eq!(state.last_namespace("ctx2"), Some("ns-b"));
+    }
+
+    #[test]
+    fn last_namespace_overwrites() {
+        let mut state = AppState::default();
+        state.set_last_namespace("ctx1", "old");
+        state.set_last_namespace("ctx1", "new");
+        assert_eq!(state.last_namespace("ctx1"), Some("new"));
+    }
+
+    #[test]
+    fn state_without_last_namespace_field_still_loads() {
+        let state: AppState = serde_json::from_str(r#"{"namespaces":{"ctx1":["ns-a"]}}"#).unwrap();
+        assert_eq!(state.get_namespaces("ctx1"), vec!["ns-a"]);
+        assert!(state.last_namespace("ctx1").is_none());
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -19,9 +19,9 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3), // Header
-            Constraint::Min(0),    // Main
-            Constraint::Length(1), // Footer
+            Constraint::Length(3),
+            Constraint::Min(0),
+            Constraint::Length(1),
         ])
         .split(f.area());
 
@@ -97,7 +97,11 @@ fn draw_header(f: &mut Frame, app: &App, area: Rect) {
     let info_text = format!(
         " Ctx: {} | NS: {} | Items: {}{}{}",
         app.current_context,
-        app.current_namespace,
+        if app.has_namespace() {
+            app.current_namespace.as_str()
+        } else {
+            "<none>"
+        },
         app.filtered_items.len(),
         filter_part,
         status_part,
@@ -227,8 +231,8 @@ fn draw_confirm(f: &mut Frame, app: &App) {
         .map(|a| a.message())
         .unwrap_or_else(|| "Confirm action?".to_string());
     let max_line = msg.lines().map(|l| l.len()).max().unwrap_or(15);
-    let w = (max_line as u16 + 4).max(30); // +2 borders, +2 padding
-    let h = (msg.lines().count() as u16 + 4).max(7); // +2 borders, +2 for [y/n] line
+    let w = (max_line as u16 + 4).max(30);
+    let h = (msg.lines().count() as u16 + 4).max(7);
     let area = centered_fixed_rect(w, h, f.area());
     f.render_widget(Clear, area);
 

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -9,6 +9,7 @@ pub const COLOR_STATUS_ERROR: Color = Color::Red;
 pub const COLOR_STATUS_TERMINATING: Color = Color::Magenta;
 pub const COLOR_STATUS_SUCCEEDED: Color = Color::Cyan;
 pub const COLOR_VERSION: Color = Color::DarkGray;
+pub const COLOR_TELEPORT: Color = Color::Yellow;
 
 pub const STYLE_NORMAL: Style = Style::new().fg(COLOR_TEXT);
 pub const STYLE_HIGHLIGHT: Style = Style::new()

--- a/src/ui/views/deployments_view.rs
+++ b/src/ui/views/deployments_view.rs
@@ -14,7 +14,16 @@ pub fn draw(f: &mut Frame, app: &mut App, area: Rect) {
     let sort_col = app.active_sort_column();
     let sort_ind = app.active_sort_direction().indicator();
     let base: &[&str] = if wide {
-        &["", "Name", "Ready", "Up-to-date", "Available", "Age", "Strategy", "Images"]
+        &[
+            "",
+            "Name",
+            "Ready",
+            "Up-to-date",
+            "Available",
+            "Age",
+            "Strategy",
+            "Images",
+        ]
     } else {
         &["", "Name", "Ready", "Up-to-date", "Available", "Age"]
     };
@@ -84,9 +93,7 @@ pub fn draw(f: &mut Frame, app: &mut App, area: Rect) {
                 cells.push(Cell::from(strategy));
                 cells.push(Cell::from(images));
             }
-            Row::new(cells)
-                .height(1)
-                .style(STYLE_NORMAL)
+            Row::new(cells).height(1).style(STYLE_NORMAL)
         })
         .collect();
 
@@ -119,7 +126,9 @@ pub fn draw(f: &mut Frame, app: &mut App, area: Rect) {
     };
 
     if app.filtered_items.is_empty() && !app.is_active_tab_loading() {
-        let msg = if app.last_error.is_some() {
+        let msg = if !app.has_namespace() {
+            "No namespace selected — press n to choose one"
+        } else if app.last_error.is_some() {
             ""
         } else if app.filter_query.is_empty() {
             "No deployments in this namespace"

--- a/src/ui/views/help_view.rs
+++ b/src/ui/views/help_view.rs
@@ -48,7 +48,7 @@ static LIST_ACTIONS: Section = ("Actions", &[
 ]);
 
 static LIST_GLOBAL: Section = ("Global", &[
-    ("c            ", "Switch context"),
+    ("c            ", "Switch context (⚡ = Teleport login)"),
     ("n            ", "Switch namespace"),
     ("P            ", "Active port forwards"),
     ("q / Ctrl+C   ", "Quit"),

--- a/src/ui/views/pods_view.rs
+++ b/src/ui/views/pods_view.rs
@@ -14,7 +14,9 @@ pub fn draw(f: &mut Frame, app: &mut App, area: Rect) {
     let sort_col = app.active_sort_column();
     let sort_ind = app.active_sort_direction().indicator();
     let base: &[&str] = if wide {
-        &["", "Name", "Ready", "Status", "Restarts", "Age", "IP", "Node", "Image"]
+        &[
+            "", "Name", "Ready", "Status", "Restarts", "Age", "IP", "Node", "Image",
+        ]
     } else {
         &["", "Name", "Ready", "Status", "Restarts", "Age"]
     };
@@ -36,8 +38,7 @@ pub fn draw(f: &mut Frame, app: &mut App, area: Rect) {
             let marker = if selected { "●" } else { " " };
 
             let KubeResource::Pod(p) = item else {
-                return Row::new(vec![Cell::from(marker), Cell::from(item.name())])
-                    .height(1);
+                return Row::new(vec![Cell::from(marker), Cell::from(item.name())]).height(1);
             };
 
             let name = p.metadata.name.as_deref().unwrap_or_default();
@@ -75,9 +76,7 @@ pub fn draw(f: &mut Frame, app: &mut App, area: Rect) {
                 Cell::from(age),
             ];
             if wide {
-                let ip = status_obj
-                    .and_then(|s| s.pod_ip.as_deref())
-                    .unwrap_or("-");
+                let ip = status_obj.and_then(|s| s.pod_ip.as_deref()).unwrap_or("-");
                 let node = p
                     .spec
                     .as_ref()
@@ -132,7 +131,9 @@ pub fn draw(f: &mut Frame, app: &mut App, area: Rect) {
     };
 
     if app.filtered_items.is_empty() && !app.is_active_tab_loading() {
-        let msg = if app.last_error.is_some() {
+        let msg = if !app.has_namespace() {
+            "No namespace selected — press n to choose one"
+        } else if app.last_error.is_some() {
             ""
         } else if app.filter_query.is_empty() && app.status_filter.is_empty() {
             "No pods in this namespace"

--- a/src/ui/views/popup_view.rs
+++ b/src/ui/views/popup_view.rs
@@ -39,6 +39,19 @@ fn draw_context_popup(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect)
             };
             ListItem::new(Span::raw(label))
         })
+        .chain(app.teleport.clusters().iter().map(|cluster| {
+            ListItem::new(Line::from(vec![
+                Span::styled("⚡ ", Style::default().fg(COLOR_TELEPORT)),
+                Span::raw(cluster.as_str()),
+                Span::styled(" (teleport)", Style::default().fg(COLOR_TELEPORT)),
+            ]))
+        }))
+        .chain(app.teleport.needs_login().then(|| {
+            ListItem::new(Span::styled(
+                "⚡ Log in to Teleport (tsh login)",
+                Style::default().fg(COLOR_TELEPORT),
+            ))
+        }))
         .collect();
 
     let list = List::new(list_items)
@@ -166,7 +179,7 @@ fn draw_port_forward_list(f: &mut Frame, app: &mut App) {
         .collect();
 
     let max_line = entries.iter().map(|s| s.len()).max().unwrap_or(20);
-    let w = (max_line as u16 + 2 + 3).max(30); // +2 borders, +3 highlight ">> "
+    let w = (max_line as u16 + 2 + 3).max(30);
     let h = (entries.len() as u16 + 2).max(4);
     let area = centered_fixed_rect(w, h, f.area());
     f.render_widget(Clear, area);

--- a/src/ui/views/secrets_view.rs
+++ b/src/ui/views/secrets_view.rs
@@ -62,8 +62,10 @@ pub fn draw(f: &mut Frame, app: &mut App, area: Rect) {
     .highlight_spacing(HighlightSpacing::Always);
 
     if app.filtered_items.is_empty() && !app.is_active_tab_loading() {
-        let msg = if app.last_error.is_some() {
-            "" // error shown in footer
+        let msg = if !app.has_namespace() {
+            "No namespace selected — press n to choose one"
+        } else if app.last_error.is_some() {
+            ""
         } else if app.filter_query.is_empty() {
             "No secrets in this namespace"
         } else {

--- a/src/ui/views/shell_view.rs
+++ b/src/ui/views/shell_view.rs
@@ -20,7 +20,7 @@ pub fn draw(f: &mut Frame, app: &App) {
     let (rows, cols) = screen.size();
     let cursor = screen.cursor_position();
 
-    let inner_height = area.height.saturating_sub(2); // borders
+    let inner_height = area.height.saturating_sub(2);
     let inner_width = area.width.saturating_sub(2);
 
     let mut lines: Vec<Line> = Vec::with_capacity(rows as usize);


### PR DESCRIPTION
## Teleport support + automatic cluster and namespace discovery

### Teleport

The context picker (`c`) now lists Teleport clusters you have access to but haven't run
`tsh kube login` for, marked `⚡`. Selecting one performs the login (TUI suspends so MFA and
browser redirects work) and switches to the new context. An expired session offers
`⚡ Log in to Teleport` instead.

`tsh kube login` is always passed `--disable-access-request` — picking a row in a list must never
file a server-side approval request.

### Namespace discovery

Namespace-scoped users get 403 on cluster-wide `list namespaces`, leaving the picker empty. kr now
falls back to `kubectl get namespaces`, then to Teleport role grants read from `tsh status`. Since
those grants are a union across all roles, they're narrowed to what actually works in the current
cluster via `SelfSubjectRulesReview` (needs no special permission). Measured 25 candidates → 3 on a
real cluster.

kr no longer invents a `default` namespace: with nothing known, none is selected and no requests
are made, so you get an empty view instead of a permission error caused by kr's own guess. Once the
list is known, a single namespace or a confirmed `default` is selected automatically; otherwise the
picker opens. The choice is remembered per context.

### Fixes

- **Terminal denials weren't detected.** Teleport answers denied requests with `404 + "access
  denied"`, not 403, so the watcher retried forever behind a spinner that never cleared. Also
  `Status::is_forbidden()` matches on `reason` and ignores the HTTP code, so a bare 403 slipped
  through. Both handled by a single `is_access_denied` predicate.
- **`kr.log` grew unbounded** . Rotated at startup past 16 MB.
- **Unit tests could write to the real config file** — `AppState` now has a test-only no-persist
  flag.

### No impact without Teleport

`tsh` is optional. When absent, one failed spawn (~150µs, cached) and nothing else: no `⚡` entries,
no extra latency, popup rendering unchanged. Full suite passes with `PATH=/nonexistent`.